### PR TITLE
fix npm warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ FROM node:lts-alpine as builder
 # Install the metrics middleware plugin
 RUN mkdir -p /verdaccio/plugins \
     && cd /verdaccio/plugins \
-    && npm install --global-style --no-bin-links --no-optional @xlts.dev/verdaccio-prometheus-middleware@1.0.0
+    && npm install --global-style --no-bin-links --omit=optional @xlts.dev/verdaccio-prometheus-middleware@1.0.0
 
 # The final built image will be based on the standard Verdaccio docker image.
 FROM verdaccio/verdaccio:5.2.0


### PR DESCRIPTION
Remove npm WARN config optional Use `--omit=optional` to exclude optional dependencies warning

eg:

```
 ---> Running in 76952288c8c5
npm WARN config optional Use `--omit=optional` to exclude optional dependencies, or
npm WARN config `--include=optional` to include them.
npm WARN config 
npm WARN config     Default value does install optional deps unless otherwise omitted.
```